### PR TITLE
Fix typo in Go installer and clean utility function

### DIFF
--- a/go/install.sh
+++ b/go/install.sh
@@ -7,7 +7,7 @@ source ~/bin/utils_sirkkalap.sh
 
 distro=$(utils_sirkkalap::distro)
 
-if [[ ${distro} == darvin ]]; then
+if [[ ${distro} == darwin ]]; then
     brew install go
 fi
 

--- a/utils_sirkkalap.sh
+++ b/utils_sirkkalap.sh
@@ -102,14 +102,6 @@ function utils_sirkkalap::confirm () {
     esac
 }
 
-function utils_sirkkalap::block() {
-    text="* $@ *"
-    chars=${#text}
-    printf '*%.0s' $(seq 1 $chars); echo
-    echo "$text"
-    printf '*%.0s' $(seq 1 $chars); echo; echo
-}
-
 # Print out a block of *'s and the given text inside it
 function utils_sirkkalap::block() {
     text="* $@ *"


### PR DESCRIPTION
## Summary
- correct Darwin OS check in Go installer
- drop duplicate `utils_sirkkalap::block` function definition

## Testing
- `shellcheck go/install.sh utils_sirkkalap.sh`

------
https://chatgpt.com/codex/tasks/task_e_686edd295fbc83299d71d31f0acb34a4