### PR TITLE
Refactor install scripts

### DIFF
--- a/GeekTool/install.sh
+++ b/GeekTool/install.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-source ~/bin/utils_sirkkalap.sh
-
-distro=$(utils_sirkkalap::distro)
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install GeekTools on Ubuntu yet..."

--- a/VirtualBox/install.sh
+++ b/VirtualBox/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=virtualbox
 CASK=cask

--- a/anaconda/install.sh
+++ b/anaconda/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=anaconda
 CASK=cask

--- a/docker/cred_helper/install.sh
+++ b/docker/cred_helper/install.sh
@@ -2,14 +2,11 @@
 
 # https://github.com/docker/docker-credential-helpers
 set -e
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
-
-source ~/bin/utils_sirkkalap.sh
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
 go get github.com/docker/docker-credential-helpers
 cd ${GOPATH}/src/github.com/docker/docker-credential-helpers
-
-distro=$(utils_sirkkalap::distro)
 
 if [[ ${distro} == centos* ]]; then
     service=secretservice

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     sudo apt update

--- a/drag-scroll/install.sh
+++ b/drag-scroll/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install GeekTools on Ubuntu yet..."

--- a/go/install.sh
+++ b/go/install.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 cd $BASEDIR
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ ${distro} == darvin ]]; then
     brew install go

--- a/google-chrome/install.sh
+++ b/google-chrome/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install chrome on Ubuntu yet..."

--- a/helm/install.sh
+++ b/helm/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=helm
 CASK=

--- a/install_utils.sh
+++ b/install_utils.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Common helper for install.sh scripts
+
+# Include guard
+[[ -n "$_LIB_INSTALL_UTILS" ]] && return || readonly _LIB_INSTALL_UTILS=1
+
+function install_utils::init() {
+    BASEDIR=$(cd "$(dirname "$1")" && /bin/pwd)
+    source ~/bin/utils_sirkkalap.sh
+    distro=$(utils_sirkkalap::distro)
+}

--- a/intellij-idea/install.sh
+++ b/intellij-idea/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 #if [[ "${distro}" == Ubuntu* ]]; then
 #fi

--- a/iterm/install.sh
+++ b/iterm/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install iterm on Ubuntu yet..."

--- a/itsycal/install.sh
+++ b/itsycal/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=itsycal
 CASK=

--- a/java/install.sh
+++ b/java/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install java on Ubuntu yet..."

--- a/java11/install.sh
+++ b/java11/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install java on Ubuntu yet..."

--- a/java14/install.sh
+++ b/java14/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install java on Ubuntu yet..."

--- a/java17/install.sh
+++ b/java17/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install java on Ubuntu yet..."

--- a/java8/install.sh
+++ b/java8/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install java on Ubuntu yet..."

--- a/jq/install.sh
+++ b/jq/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=jq
 CASK=

--- a/leiningen/install.sh
+++ b/leiningen/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install leiningen on Ubuntu yet..."

--- a/me.sh
+++ b/me.sh
@@ -23,6 +23,7 @@ echo "~/bin" >~/.paths.d/home_bin
 echo "/opt/homebrew/bin" >~/.paths.d/opt_homebrew_bin
 echo "/opt/homebrew/opt/libpq/bin" >~/.paths.d/opt_homebrew_opt_libpq_bin
 ln -s -f ${WORK}/dotfiles-sirkkalap/utils_sirkkalap.sh ~/bin/
+ln -s -f ${WORK}/dotfiles-sirkkalap/install_utils.sh ~/bin/
 
 
 DISTRO=$(utils_sirkkalap::distro)

--- a/minikube/install.sh
+++ b/minikube/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=minikube
 CASK=

--- a/nvm/install.sh
+++ b/nvm/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     echo "Sorry, I do not know how to install nvm on Ubuntu yet..."

--- a/rclone/install.sh
+++ b/rclone/install.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 cd ${BASEDIR}
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 # - https://rclone.org/downloads/
 if [[ ${distro} == Ubuntu* ]]; then

--- a/rectangle/install.sh
+++ b/rectangle/install.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-BASEDIR=$(cd $(dirname $0); /bin/pwd)
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=rectangle
 CASK=

--- a/slack/install.sh
+++ b/slack/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 #if [[ "${distro}" == Ubuntu* ]]; then
 #fi

--- a/sublimetext/install.sh
+++ b/sublimetext/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 # https://linuxize.com/post/how-to-install-sublime-text-3-on-ubuntu-18-04/
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 if [[ "${distro}" == Ubuntu* ]]; then
     sudo apt update

--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
 
-source ~/bin/utils_sirkkalap.sh
 
-distro=$(utils_sirkkalap::distro)
 
 PACKAGE=vagrant
 CASK=cask


### PR DESCRIPTION
## Summary
- add `install_utils.sh` helper
- use the helper from install scripts to avoid repeating code
- symlink helper in `me.sh`

## Testing
- `shellcheck install_utils.sh GeekTool/install.sh VirtualBox/install.sh anaconda/install.sh docker/install.sh docker/cred_helper/install.sh drag-scroll/install.sh go/install.sh google-chrome/install.sh helm/install.sh intellij-idea/install.sh iterm/install.sh itsycal/install.sh java/install.sh java11/install.sh java14/install.sh java17/install.sh java8/install.sh jq/install.sh leiningen/install.sh minikube/install.sh nvm/install.sh rclone/install.sh rectangle/install.sh slack/install.sh sublimetext/install.sh vagrant/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_686eddd52e148329b40f5ee08fda18bc