### PR TITLE
Update error message in drag-scroll installer

### DIFF
--- a/drag-scroll/install.sh
+++ b/drag-scroll/install.sh
@@ -5,7 +5,7 @@ install_utils::init "$0"
 
 
 if [[ "${distro}" == Ubuntu* ]]; then
-    echo "Sorry, I do not know how to install GeekTools on Ubuntu yet..."
+    echo "Sorry, I do not know how to install dragscroll on Ubuntu yet..."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- fix the installation message on Ubuntu for drag-scroll

## Testing
- `bash -n drag-scroll/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ee121844c83298a304332e052649a