### PR TITLE
Fix java_home test exit status

### DIFF
--- a/bin/test-java_home.sh
+++ b/bin/test-java_home.sh
@@ -5,4 +5,7 @@ j18home=$(/usr/libexec/java_home -v 1.8)
 if [ "${j18home}" != "/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home" ]
 then
     echo "java_home execution failed with result: ${j18home}"
+    exit 1
 fi
+
+exit 0


### PR DESCRIPTION
## Summary
- ensure `bin/test-java_home.sh` fails when the java path check fails

## Testing
- `shellcheck bin/test-java_home.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ee133a9248329a17ab82fd52c3bdb