### PR TITLE
Add installer for IntelliJ IDEA Community Edition

### DIFF
--- a/intellij-idea-ce/install.sh
+++ b/intellij-idea-ce/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
+
+#if [[ "${distro}" == Ubuntu* ]]; then
+#fi
+
+if [[ "${distro}" == darwin ]]; then
+    brew install intellij-idea-ce
+fi


### PR DESCRIPTION
## Summary
- add install script for IntelliJ IDEA Community Edition via Homebrew

## Testing
- `bash -n intellij-idea-ce/install.sh`
- `shellcheck intellij-idea-ce/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8c774ee9883299a5d2aa7015697d4