### PR TITLE
Add Mac Mouse Fix installer

### DIFF
--- a/mac-mouse-fix/install.sh
+++ b/mac-mouse-fix/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+source ~/bin/install_utils.sh
+install_utils::init "$0"
+
+
+
+PACKAGE=mac-mouse-fix
+CASK=
+
+if [[ "${distro}" == Ubuntu* ]]; then
+    echo "Sorry, I do not know how to install $PACKAGE on Ubuntu yet..."
+    exit 1
+fi
+
+if [[ "${distro}" == darwin ]]; then
+    brew $CASK install $PACKAGE </dev/null
+fi


### PR DESCRIPTION
## Summary
- add installer script for Mac Mouse Fix via Homebrew

## Testing
- `bash -n mac-mouse-fix/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8c95bc6608329a20908a905ad636f