### PR TITLE
Standardize Ubuntu warning punctuation in installers

### DIFF
--- a/GeekTool/install.sh
+++ b/GeekTool/install.sh
@@ -4,7 +4,7 @@ source ~/bin/install_utils.sh
 install_utils::init "$0"
 
 if [[ "${distro}" == Ubuntu* ]]; then
-    echo "Sorry, I do not know how to install GeekTools on Ubuntu yet..."
+    echo "Sorry, I do not know how to install GeekTools on Ubuntu yet."
     exit 1
 fi
 

--- a/drag-scroll/install.sh
+++ b/drag-scroll/install.sh
@@ -5,7 +5,7 @@ install_utils::init "$0"
 
 
 if [[ "${distro}" == Ubuntu* ]]; then
-    echo "Sorry, I do not know how to install dragscroll on Ubuntu yet..."
+    echo "Sorry, I do not know how to install dragscroll on Ubuntu yet."
     exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Ensure Ubuntu warning messages are consistent across installer scripts by standardizing punctuation.
- Make user-facing text reference package names (`dragscroll`, `GeekTools`) in a consistent style.
- Keep installer behavior unchanged while improving message clarity.

### Description
- Replace the trailing ellipsis with a period in the Ubuntu warning in `drag-scroll/install.sh` and `GeekTool/install.sh`.
- No functional logic changes: both scripts still `exit 1` on Ubuntu and continue to use Homebrew on `darwin`.
- Updated files: `drag-scroll/install.sh` and `GeekTool/install.sh`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953040f49e083298baef461aaa3598e)